### PR TITLE
Fix undefined dependencies error

### DIFF
--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -50,9 +50,10 @@ const pathUtils = {
               return false;
             }
 
-            const {dependencies, devDependencies} = await file.readJson(
-              packageJsonPath
-            );
+            const {
+              dependencies = {},
+              devDependencies = {}
+            } = await file.readJson(packageJsonPath);
 
             if (dependencies['flow-bin'] || devDependencies['flow-bin']) {
               packagePaths.push(packagePath);


### PR DESCRIPTION
This fixes the following error, when `dependencies` or `devDependencies` is not defined within a `package.json`:

```
$ yarn flow-mono create-symlinks .flowconfig
yarn run v1.3.2
$ /Users/stevehollaar/foo/node_modules/.bin/flow-mono create-symlinks .flowconfig
  ℹINFO::flow-mono-cli: Creating symlinks to the defined ".flowconfig" and dependencies to all packages with a "flow-bin" dependency. +0ms
✖FATAL::flow-mono-cli: Cannot read property 'flow-bin' of undefined
     at fn.catch.e (/Users/stevehollaar1/foo/node_modules/flow-mono-cli/dist/lib/async.js:12:42)
    at <anonymous>
error Command failed with exit code 1.
```