### PR TITLE
Add support for relative symlinks in create-symlinks command

### DIFF
--- a/bin/flow-mono
+++ b/bin/flow-mono
@@ -30,9 +30,16 @@ const _ = require('yargs')
       type: 'string',
       describe: 'The relative path to the `.flowconfig` for which symlinks will be created in all packages with a `flow-bin` dependency'
     })
+    yargs.option('relative', {
+      alias: 'r',
+      type: 'boolean',
+      default: false,
+      describe: 'If passed the symlinks will be relative paths instead of absolute'
+    })
   }, argv => {
     asyncUtils.exec(createFlowTypeSymlinks, {
-      flowConfigPath: argv.path
+      flowConfigPath: argv.path,
+      relative: argv.relative
     });
   })
   .command('install-types', 'Installs flow-typed typings for all mono-repo package dependencies', () => {}, () => {

--- a/docs/cli/create-symlinks.md
+++ b/docs/cli/create-symlinks.md
@@ -16,7 +16,13 @@ $ flow-mono create-symlinks ./build/.flowconfig
 
 #### Options and Arguments
 
-The only argument provided should be the relative path to the fallback / singleton `.flowconfig`.
+##### `[flowconfig-path]`
+
+The relative path to the fallback / singleton `.flowconfig`.
+
+##### `-r, --relative`  \(Optional\)
+
+Create relative symlinks (e.g. ../../../build/.flowconfig) instead of absolute symlinks (e.g. /path/to/build/.flowconfig)
 
 #### Configuration
 

--- a/src/commands/__snapshots__/create-symlinks.spec.js.snap
+++ b/src/commands/__snapshots__/create-symlinks.spec.js.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     "/usr/app/foo/.flowconfig",
     "/foo/baz",
+    false,
   ],
 ]
 `;
@@ -15,11 +16,13 @@ Array [
     "baz-dependency",
     "/foo",
     "/foo/bar",
+    false,
   ],
   Array [
     "baz-dependency",
     "/foo",
     "/foo/baz",
+    false,
   ],
 ]
 `;

--- a/src/commands/create-symlinks.js
+++ b/src/commands/create-symlinks.js
@@ -9,7 +9,7 @@ const file = require('./../lib/file.js');
 const {info, success} = require('./../lib/logger.js');
 
 module.exports = async function createFlowTypeSymlinks(
-  {flowConfigPath}: {flowConfigPath: string},
+  {flowConfigPath, relative}: {flowConfigPath: string, relative: boolean},
   cwd?: string = process.cwd()
 ) {
   const cliConfig = await config.resolveAndReadConfig();
@@ -27,7 +27,7 @@ module.exports = async function createFlowTypeSymlinks(
       const existsFlowConfig = await file.existsAsync(join(packagePath, '.flowconfig'));
 
       if (existsFlowConfig === false) {
-        await file.createSymlink(absoluteFlowConfigPath, packagePath);
+        await file.createSymlink(absoluteFlowConfigPath, packagePath, relative);
       }
 
       const packageJson = await dependency.readPackageJson(packagePath);
@@ -36,7 +36,7 @@ module.exports = async function createFlowTypeSymlinks(
 
       await Promise.all(
         dependencyKeys.filter(key => ignoredPackageKeys.includes(key) === false).map(key => {
-          return dependency.createSymlinkForDependency(key, rootPath, packagePath);
+          return dependency.createSymlinkForDependency(key, rootPath, packagePath, relative);
         })
       );
     })

--- a/src/commands/create-symlinks.spec.js
+++ b/src/commands/create-symlinks.spec.js
@@ -34,7 +34,7 @@ describe('create-symlinks', () => {
     dependency.readPackageJson.mockReturnValue({});
     dependency.mergeDependenciesIntoList.mockReturnValue(['foo-dependency', 'bar-dependency', 'baz-dependency']);
 
-    await createFlowTypeSymlinks({flowConfigPath: '/foo/.flowconfig'}, '/usr/app');
+    await createFlowTypeSymlinks({flowConfigPath: '/foo/.flowconfig', relative: false}, '/usr/app');
 
     expect(file.createSymlink.mock.calls).toMatchSnapshot();
     expect(dependency.createSymlinkForDependency.mock.calls).toMatchSnapshot();

--- a/src/lib/dependency.js
+++ b/src/lib/dependency.js
@@ -166,7 +166,7 @@ const dependencyUtils = {
    * @param  {String}  packageDir The package directory in whichs `node_modules` folder we should create the symlink.
    * @return {Promise}            A Promise that resolves once the symlink was created.
    */
-  async createSymlinkForDependency(key: string, rootDir: string, packageDir: string) {
+  async createSymlinkForDependency(key: string, rootDir: string, packageDir: string, relative: booelan) {
     this.ensureDependencyScopeExists(key, packageDir);
 
     const scope = this.getScopeForDependency(key);
@@ -187,7 +187,7 @@ const dependencyUtils = {
       return;
     }
 
-    await file.createSymlink(src, distDir);
+    await file.createSymlink(src, distDir, relative);
   }
 };
 

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -1,7 +1,8 @@
 // @flow
 
 const fs = require('fs');
-const {basename, join} = require('path');
+const process = require('process');
+const path = require('path');
 const {promisify} = require('util');
 const {error} = require('./logger.js');
 
@@ -16,13 +17,21 @@ const _utils = {
 const fileUtils = {
   _utils,
 
-  async createSymlink(target: string, distDir: string) {
-    const dist = join(distDir, basename(target));
+  async createSymlink(target: string, distDir: string, relative: boolean) {
+    const dist = path.join(distDir, path.basename(target));
     const stats = await _utils.statAsync(target);
     // Use a junction on Windows like Yarn do.
     // See: https://github.com/yarnpkg/yarn/blob/fc94a16b7ca90a188d084aef8cea406b60e8c38f/src/util/fs.js#L695-L696
     const type = stats.isDirectory() ? 'junction' : 'file';
-    await _utils.symlinkAsync(target, dist, type);
+    let targetRelative = target;
+    if (relative) {
+      targetRelative = path.relative(path.dirname(dist), target);
+    }
+
+    const currDur = process.cwd();
+    process.chdir(distDir);
+    await _utils.symlinkAsync(targetRelative, path.basename(target), type);
+    process.chdir(currDur);
   },
 
   /**


### PR DESCRIPTION
I had a similar issue as #190, so decided to implement it myself.

I added it as a new `--relative` option to the `create-symlinks` command, to preserver API compat. However, I'm not sure when it would be preferable to use absolute links in a situation like this, so maybe it makes sense to default to relative paths?